### PR TITLE
sharp: fix to reset LCDIF module before running linux

### DIFF
--- a/board/sharp/common/dma.c
+++ b/board/sharp/common/dma.c
@@ -1,6 +1,7 @@
 #include <common.h>
 #include <bootm.h>
 #include <asm/mach-imx/dma.h>
+#include <asm/arch/sys_proto.h>
 
 void board_quiesce_devices(void) {
 	mxs_dma_disable(MXS_DMA_CHANNEL_AHB_APBH_LCDIF);

--- a/board/sharp/common/dma.c
+++ b/board/sharp/common/dma.c
@@ -4,4 +4,6 @@
 
 void board_quiesce_devices(void) {
 	mxs_dma_disable(MXS_DMA_CHANNEL_AHB_APBH_LCDIF);
+	mxs_dma_release(MXS_DMA_CHANNEL_AHB_APBH_LCDIF);
+	lcdif_power_down();
 }


### PR DESCRIPTION
2世代機種にてLCDIFがLinux移行後に異常状態にならぬように、事前に止めるように修正