### PR TITLE
Fix CPU clock

### DIFF
--- a/board/sharp/common/Makefile
+++ b/board/sharp/common/Makefile
@@ -4,3 +4,4 @@ obj-$(CONFIG_VIDEO_MXS)	+= dma.o
 else
 obj- = __dummy__.o
 endif
+obj-y	:= cpu_clkdiv.o

--- a/board/sharp/common/cpu_clkdiv.c
+++ b/board/sharp/common/cpu_clkdiv.c
@@ -1,0 +1,14 @@
+#include <common.h>
+#include <asm/io.h>
+#include <asm/arch/clock.h>
+#include <asm/arch/imx-regs.h>
+
+void mxs_set_divcpu(uint8_t clkdiv) {
+	struct mxs_clkctrl_regs *clkctrl_regs =
+		(struct mxs_clkctrl_regs *)MXS_CLKCTRL_BASE;
+	uint32_t clkctrl;
+	clkctrl = readl(&clkctrl_regs->hw_clkctrl_cpu);
+	clkctrl &= ~0x3F;
+	clkctrl |= (clkdiv & 0x3F);
+	writel(clkctrl, &clkctrl_regs->hw_clkctrl_cpu);
+}

--- a/board/sharp/common/cpu_clkdiv.h
+++ b/board/sharp/common/cpu_clkdiv.h
@@ -1,0 +1,3 @@
+#include <common.h>
+
+void mxs_set_divcpu(uint8_t clkdiv);

--- a/board/sharp/pwa7200/pwa7200.c
+++ b/board/sharp/pwa7200/pwa7200.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 
 #include "../common/lcd.h"
+#include "../common/cpu_clkdiv.h"
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -46,6 +47,8 @@ int board_early_init_f(void)
 	mxs_set_sspclk(MXC_SSPCLK0, 96000, 0);
 	/* SSP1 clock at 96MHz */
 	mxs_set_sspclk(MXC_SSPCLK1, 96000, 0);
+	/* set cpu clock div 1(480MHz)*/
+	mxs_set_divcpu(1);
 
 #ifdef CONFIG_CMD_USB
 	mxs_iomux_setup_pad(MX28_PAD_SSP2_SS1__USB1_OVERCURRENT);

--- a/board/sharp/pwa7400/pwa7400.c
+++ b/board/sharp/pwa7400/pwa7400.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 
 #include "../common/lcd.h"
+#include "../common/cpu_clkdiv.h"
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -46,6 +47,8 @@ int board_early_init_f(void)
 	mxs_set_sspclk(MXC_SSPCLK0, 96000, 0);
 	/* SSP1 clock at 96MHz */
 	mxs_set_sspclk(MXC_SSPCLK1, 96000, 0);
+	/* set cpu clock div 1(480MHz)*/
+	mxs_set_divcpu(1);
 
 #ifdef CONFIG_CMD_USB
 	mxs_iomux_setup_pad(MX28_PAD_SSP2_SS1__USB1_OVERCURRENT);

--- a/board/sharp/pwsh1/pwsh1.c
+++ b/board/sharp/pwsh1/pwsh1.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 
 #include "../common/lcd.h"
+#include "../common/cpu_clkdiv.h"
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -43,6 +44,8 @@ int board_early_init_f(void)
 	mxs_set_sspclk(MXC_SSPCLK0, 96000, 0);
 	/* SSP1 clock at 96MHz */
 	mxs_set_sspclk(MXC_SSPCLK1, 96000, 0);
+	/* set cpu clock div 1(480MHz)*/
+	mxs_set_divcpu(1);
 
 #ifdef CONFIG_CMD_USB
 	mxs_iomux_setup_pad(MX28_PAD_SSP2_SS1__USB1_OVERCURRENT);

--- a/board/sharp/pwsh2/pwsh2.c
+++ b/board/sharp/pwsh2/pwsh2.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 
 #include "../common/lcd.h"
+#include "../common/cpu_clkdiv.h"
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -43,6 +44,8 @@ int board_early_init_f(void)
 	mxs_set_sspclk(MXC_SSPCLK0, 96000, 0);
 	/* SSP1 clock at 96MHz */
 	mxs_set_sspclk(MXC_SSPCLK1, 96000, 0);
+	/* set cpu clock div 1(480MHz)*/
+	mxs_set_divcpu(1);
 
 #ifdef CONFIG_CMD_USB
 	mxs_iomux_setup_pad(MX28_PAD_SSP2_SS1__USB1_OVERCURRENT);

--- a/board/sharp/pwsh3/pwsh3.c
+++ b/board/sharp/pwsh3/pwsh3.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 
 #include "../common/lcd.h"
+#include "../common/cpu_clkdiv.h"
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -43,6 +44,8 @@ int board_early_init_f(void)
 	mxs_set_sspclk(MXC_SSPCLK0, 96000, 0);
 	/* SSP1 clock at 96MHz */
 	mxs_set_sspclk(MXC_SSPCLK1, 96000, 0);
+	/* set cpu clock div 1(480MHz)*/
+	mxs_set_divcpu(1);
 
 #ifdef CONFIG_CMD_USB
 	mxs_iomux_setup_pad(MX28_PAD_SSP2_SS1__USB1_OVERCURRENT);

--- a/board/sharp/pwsh4/pwsh4.c
+++ b/board/sharp/pwsh4/pwsh4.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 
 #include "../common/lcd.h"
+#include "../common/cpu_clkdiv.h"
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -43,6 +44,8 @@ int board_early_init_f(void)
 	mxs_set_sspclk(MXC_SSPCLK0, 96000, 0);
 	/* SSP1 clock at 96MHz */
 	mxs_set_sspclk(MXC_SSPCLK1, 96000, 0);
+	/* set cpu clock div 1(480MHz)*/
+	mxs_set_divcpu(1);
 
 #ifdef CONFIG_CMD_USB
 	mxs_iomux_setup_pad(MX28_PAD_SSP2_SS1__USB1_OVERCURRENT);

--- a/board/sharp/pwsh5/pwsh5.c
+++ b/board/sharp/pwsh5/pwsh5.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 
 #include "../common/lcd.h"
+#include "../common/cpu_clkdiv.h"
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -43,6 +44,8 @@ int board_early_init_f(void)
 	mxs_set_sspclk(MXC_SSPCLK0, 96000, 0);
 	/* SSP1 clock at 96MHz */
 	mxs_set_sspclk(MXC_SSPCLK1, 96000, 0);
+	/* set cpu clock div 1(480MHz)*/
+	mxs_set_divcpu(1);
 
 #ifdef CONFIG_CMD_USB
 	mxs_iomux_setup_pad(MX28_PAD_SSP2_SS1__USB1_OVERCURRENT);

--- a/board/sharp/pwsh6/pwsh6.c
+++ b/board/sharp/pwsh6/pwsh6.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 
 #include "../common/lcd.h"
+#include "../common/cpu_clkdiv.h"
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -43,6 +44,8 @@ int board_early_init_f(void)
 	mxs_set_sspclk(MXC_SSPCLK0, 96000, 0);
 	/* SSP1 clock at 96MHz */
 	mxs_set_sspclk(MXC_SSPCLK1, 96000, 0);
+	/* set cpu clock div 1(480MHz)*/
+	mxs_set_divcpu(1);
 
 #ifdef CONFIG_CMD_USB
 	mxs_iomux_setup_pad(MX28_PAD_SSP2_SS1__USB1_OVERCURRENT);

--- a/board/sharp/pwsh7/pwsh7.c
+++ b/board/sharp/pwsh7/pwsh7.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 
 #include "../common/lcd.h"
+#include "../common/cpu_clkdiv.h"
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -43,6 +44,8 @@ int board_early_init_f(void)
 	mxs_set_sspclk(MXC_SSPCLK0, 96000, 0);
 	/* SSP1 clock at 96MHz */
 	mxs_set_sspclk(MXC_SSPCLK1, 96000, 0);
+	/* set cpu clock div 1(480MHz)*/
+	mxs_set_divcpu(1);
 
 #ifdef CONFIG_CMD_USB
 	mxs_iomux_setup_pad(MX28_PAD_SSP2_SS1__USB1_OVERCURRENT);


### PR DESCRIPTION
SDカードから直接起動する際にCPUのクロックが半分となってしまう問題を治しました。
PW-SA1で動作を確認しました。