### PR TITLE
sharp: fix x1 build and logo

### DIFF
--- a/board/sharp/common/Makefile
+++ b/board/sharp/common/Makefile
@@ -4,4 +4,6 @@ obj-$(CONFIG_VIDEO_MXS)	+= dma.o
 else
 obj- = __dummy__.o
 endif
-obj-y	:= cpu_clkdiv.o
+ifdef CONFIG_ARCH_MX28
+obj-$(CONFIG_ARCH_MX28)	+= cpu_clkdiv.o
+endif


### PR DESCRIPTION
- Compiling cpu_clkdiv.c in PW-x1 configuration breaks the build
- Add cpu_clkdiv.o rather than assigning; it accidentally removes lcd.o and dma.o